### PR TITLE
fix(pi-footer): handle pi-tui 0.84 removing TUI class

### DIFF
--- a/packages/pi-footer/src/tui-footer-shrink-padding.ts
+++ b/packages/pi-footer/src/tui-footer-shrink-padding.ts
@@ -1,4 +1,5 @@
-import { TUI, type Component } from "@earendil-works/pi-tui";
+import * as piTuiNs from "@earendil-works/pi-tui";
+import type { Component } from "@earendil-works/pi-tui";
 
 import { getFooterComponentKind } from "./footer-component.ts";
 
@@ -379,7 +380,12 @@ function padAtVisibleBoundary(
  * pads shrinking transcripts above it so status/widgets, editor, and footer stay attached.
  */
 export function installFooterShrinkPaddingPatch(): void {
-    const prototypeValue: unknown = TUI.prototype;
+    // pi-tui 0.84 split TUI into TuiMainScreen + TuiAltScreen and stopped exporting TUI.
+    // Fall back to TUI for older versions.
+    const piTuiAny = piTuiNs as Record<string, unknown>;
+    const tuiClass: unknown = piTuiAny["TuiMainScreen"] ?? piTuiAny["TUI"];
+    if (tuiClass === undefined) return;
+    const prototypeValue: unknown = (tuiClass as { prototype: unknown }).prototype;
     if (
         (typeof prototypeValue !== "object" && typeof prototypeValue !== "function") ||
         prototypeValue === null


### PR DESCRIPTION
## Problem

Pi 0.84 upgraded its bundled `@earendil-works/pi-tui` to 0.84.0, which split the `TUI` class into `TuiMainScreen` and `TuiAltScreen`. **`TUI` is no longer exported.**

Because pi's extension loader (jiti) redirects all `@earendil-works/pi-tui` imports to pi's own bundled version, `@zigai/pi-footer` now sees pi-tui 0.84 regardless of what is installed in its `node_modules`. This causes a crash at startup:

```
Error: Failed to load extension ".../pi-footer/src/index.ts":
  Cannot read properties of undefined (reading 'prototype')
```

The crash happens in `installFooterShrinkPaddingPatch()` because `TUI` is `undefined`:

```ts
const prototypeValue: unknown = TUI.prototype; // TUI is undefined → TypeError
```

## Fix

Use a namespace import and probe for whichever class is available at runtime — `TuiMainScreen` (pi-tui ≥ 0.84) or `TUI` (pi-tui ≤ 0.82). The patch logic itself is unchanged.
