### PR TITLE
fix(pi-prompt-history): avoid recursive shortcut hook

### DIFF
--- a/packages/pi-prompt-history/src/editor.ts
+++ b/packages/pi-prompt-history/src/editor.ts
@@ -1,4 +1,8 @@
-import type { ExtensionContext, KeybindingsManager } from "@earendil-works/pi-coding-agent";
+import {
+    CustomEditor,
+    type ExtensionContext,
+    type KeybindingsManager,
+} from "@earendil-works/pi-coding-agent";
 import type { EditorComponent, EditorTheme, TUI } from "@earendil-works/pi-tui";
 import { registerEditorEnhancer, type EditorEnhancerHandle } from "@zigai/pi-extension-internals";
 
@@ -14,27 +18,6 @@ export type PromptHistoryEditorContext = Pick<ExtensionContext, "hasUI"> & {
     ui: Pick<ExtensionContext["ui"], "getEditorComponent" | "setEditorComponent">;
 };
 
-function isEditorComponent(value: unknown): value is EditorComponent {
-    if (typeof value !== "object" || value === null) return false;
-
-    return (
-        typeof Reflect.get(value, "render") === "function" &&
-        typeof Reflect.get(value, "invalidate") === "function" &&
-        typeof Reflect.get(value, "getText") === "function" &&
-        typeof Reflect.get(value, "setText") === "function" &&
-        typeof Reflect.get(value, "handleInput") === "function"
-    );
-}
-
-function getFocusedEditor(tui: TUI): EditorLike | undefined {
-    const getFocusedComponent: unknown = Reflect.get(tui, "getFocusedComponent") as unknown;
-    if (typeof getFocusedComponent !== "function") return undefined;
-
-    const focused: unknown = Reflect.apply(getFocusedComponent, tui, []) as unknown;
-    if (!isEditorComponent(focused)) return undefined;
-    return focused;
-}
-
 function enhanceEditor(editor: EditorLike, history: string[]): EditorLike {
     for (const prompt of history) {
         editor.addToHistory?.(prompt);
@@ -42,12 +25,12 @@ function enhanceEditor(editor: EditorLike, history: string[]): EditorLike {
     return editor;
 }
 
-function createFocusedEditor(tui: TUI): EditorLike {
-    const editor = getFocusedEditor(tui);
-    if (editor === undefined) {
-        throw new Error("Cannot preserve the active editor while loading prompt history");
-    }
-    return editor;
+function createDefaultEditor(
+    tui: TUI,
+    theme: EditorTheme,
+    keybindings: KeybindingsManager,
+): EditorLike {
+    return new CustomEditor(tui, theme, keybindings);
 }
 
 /** Installs an editor preloaded with prompts from the current session branch. */
@@ -58,7 +41,7 @@ export function applyPromptHistoryEditor(
         return registerEditorEnhancer(
             ctx,
             PROMPT_HISTORY_EDITOR_ENHANCER,
-            (tui) => createFocusedEditor(tui),
+            createDefaultEditor,
             (editor) => editor,
         );
     }
@@ -67,7 +50,7 @@ export function applyPromptHistoryEditor(
     return registerEditorEnhancer(
         ctx,
         PROMPT_HISTORY_EDITOR_ENHANCER,
-        (tui) => createFocusedEditor(tui),
+        createDefaultEditor,
         (editor) => enhanceEditor(editor, currentPrompts),
     );
 }

--- a/packages/pi-prompt-history/test/editor.test.ts
+++ b/packages/pi-prompt-history/test/editor.test.ts
@@ -3,7 +3,12 @@ import { test } from "vitest";
 
 import { applyPromptHistoryEditor, type PromptHistoryEditorContext } from "../src/editor.ts";
 import type { UserMessage } from "@earendil-works/pi-ai";
-import { CustomEditor, type SessionEntry } from "@earendil-works/pi-coding-agent";
+import {
+    CustomEditor,
+    type KeybindingsManager,
+    type SessionEntry,
+} from "@earendil-works/pi-coding-agent";
+import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 
 type EditorFactory = NonNullable<
     Parameters<PromptHistoryEditorContext["ui"]["setEditorComponent"]>[0]
@@ -14,6 +19,11 @@ type EditorTestContext = {
     readonly addedPrompts: string[];
     readonly installedFactories: EditorFactory[];
 };
+
+function testDouble<T extends object>(value: Partial<T>): T {
+    // SAFETY: Tests supply only the members exercised by the production path under test.
+    return value as T;
+}
 
 function userEntry(content: UserMessage["content"], timestamp: number): SessionEntry {
     return {
@@ -81,7 +91,7 @@ test("prompt history preloads prompts from the current branch in branch order", 
     assert.deepEqual(context.addedPrompts, ["older current prompt", "newer current prompt"]);
 });
 
-test("prompt history preserves the host default editor and its rendering", () => {
+test("prompt history preserves a configured host editor and its rendering", () => {
     const addedPrompts: string[] = [];
     const hostEditor = {
         render(width: number) {
@@ -108,7 +118,7 @@ test("prompt history preserves the host default editor and its rendering", () =>
         },
         ui: {
             getEditorComponent() {
-                return undefined;
+                return () => hostEditor;
             },
             setEditorComponent(factory) {
                 installedFactory = factory;
@@ -133,6 +143,57 @@ test("prompt history preserves the host default editor and its rendering", () =>
     assert.equal(editor, hostEditor);
     assert.deepEqual(editor.render(80), ["<magic>workflowz</magic>"]);
     assert.deepEqual(addedPrompts, ["current prompt"]);
+});
+
+test("prompt history keeps Pi's default editor shortcut hook non-recursive", () => {
+    let installedFactory: EditorFactory | undefined;
+    const ctx: PromptHistoryEditorContext = {
+        hasUI: true,
+        sessionManager: {
+            getBranch() {
+                return [];
+            },
+        },
+        ui: {
+            getEditorComponent() {
+                return undefined;
+            },
+            setEditorComponent(factory) {
+                installedFactory = factory;
+            },
+        },
+    };
+
+    applyPromptHistoryEditor(ctx);
+    assert.notEqual(installedFactory, undefined);
+    if (installedFactory === undefined) return;
+
+    let focusedEditor: CustomEditor;
+    const testTui = testDouble<TUI>({});
+    Object.assign(testTui, {
+        getFocusedComponent() {
+            return focusedEditor;
+        },
+    });
+    const theme = testDouble<EditorTheme>({ borderColor: (text) => text });
+    const keybindings = testDouble<KeybindingsManager>({
+        matches() {
+            return false;
+        },
+    });
+    const defaultEditor = new CustomEditor(testTui, theme, keybindings);
+    focusedEditor = defaultEditor;
+    const editor = installedFactory(testTui, theme, keybindings);
+
+    assert.equal(editor instanceof CustomEditor, true);
+    if (!(editor instanceof CustomEditor)) return;
+
+    // Pi 0.84.3 delegates custom-editor shortcuts to its default editor. Returning that same
+    // instance makes the delegate call itself for every key pressed during startup.
+    editor.onExtensionShortcut ??= (data) => defaultEditor.onExtensionShortcut?.(data) ?? false;
+
+    assert.doesNotThrow(() => editor.onExtensionShortcut?.("/"));
+    assert.notEqual(editor, defaultEditor);
 });
 
 test("prompt history does not install an editor without a UI", () => {


### PR DESCRIPTION
## Problem

When `pi-prompt-history` is the first editor enhancer, its fallback factory returns Pi's currently focused default `CustomEditor` instance. Pi 0.84.3 treats the factory result as a separate custom editor and installs this shortcut delegate:

```ts
customEditor.onExtensionShortcut ||= (data) =>
  this.defaultEditor.onExtensionShortcut?.(data);
```

Because both references point to the same object, the delegate calls itself until Node throws `RangeError: Maximum call stack size exceeded`. Pi accepts input while extensions are still loading, so typing during startup can hit the recursive hook before extension shortcut setup replaces it.

## How to reproduce

There are multiple ways, but the easiest one
1. run `pi` from your terminal
2. immediately hit `Up` arrow
3. `Pi` crashes with
```
pi exiting due to uncaughtException:
RangeError: Maximum call stack size exceeded
    at customEditor.onExtensionShortcut.customEditor.onExtensionShortcut (file:///Users/eli/.cache/aube/virtual-store/@earendil-works+pi-coding-agent@0.84.3-5f84d9399b7207b4/node_modules/@earendil-works/pi-coding-agent/dist/bundle/chunks/chunk-E5KXRMZK.js:1:1)
```

## Fix

Create a fresh `CustomEditor` when the enhancer registry has no configured base factory. Configured editor factories still compose unchanged, so existing custom editors and their rendering remain preserved.

The regression test emulates Pi 0.84.3's shortcut delegate and verifies that invoking it does not recurse and that the installed editor is distinct from Pi's focused default editor.

## Verification

- `npx vitest run packages/pi-prompt-history/test/editor.test.ts` — 4 passed
- `npm run config:check` — passed
- `npm run format:check` — passed
- `npm run typecheck` — passed
- `npm test` — 65 files, 321 tests passed

`npm run check` reaches the repository-wide lint step, which currently reports pre-existing `antislop` findings across unrelated packages and pre-existing test lines. The new source and regression-test lines have no focused lint findings.
